### PR TITLE
Don't add prefixes so the path of changed files is correct.

### DIFF
--- a/internal/pre-commit
+++ b/internal/pre-commit
@@ -31,7 +31,8 @@ def main():
     changed_files = filter(None, gpk.shell([
             'git', 'diff', '--cached',
                            '--name-only',
-                           '--diff-filter=ACMR'
+                           '--diff-filter=ACMR',
+                           '--no-prefix'
             ]).split('\n'))
 
     checks = gpk.find_checks(repo_root, changed_files, gpk_path)


### PR DESCRIPTION
Without this git will include a prefix in the path of your changed files, which causes gpk to generate incorrect potential_precommit paths.